### PR TITLE
add -p parameter to blueflood-forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,12 +21,17 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+
+# IntelliJ
+.idea/
+*.iml
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -15,32 +15,24 @@ It does very primitive _'caching'_: aggregates all metrics and flushes them in r
 
 # Installation
 
+```
     git clone https://github.com/rackerlabs/blueflood-carbon-forwarder.git
     cd blueflood-carbon-forwarder
     python setup.py install
+```
 
 # Running
 
+```
     twistd blueflood-forward
-
-# Configuration
-
-Configuration is done with command line arguments passed to twistd daemon when running:
-
-    twistd -n -l - blueflood-forward --help
-
-#Logging 
-
-Logging can be controlled using LogObserver provided along or you can use your own LogObserver
-
-    twistd --logger carbonforwarderlogging.forwarder_log_observer.get_log_observer blueflood-forward
- 
+```
 | Switch | Description | default |
 | ----- | ------- | --------- |
 | -e | Endpoint to listen on for pickle protocol metrics | tcp:2004 |
 | -i | Metrics send interval, sec | 30.0 |
 | -b | Blueflood address | http://localhost:19000 |
 | -t | Tenant ID | tenant |
+| -p | Prefix to be prepended to metrics name | metric_prefix |
 | --ttl | TimeToLive value for metrics, sec | 86400 |
 | -u | Keystone user | |
 | -k | Keystone key | |
@@ -48,4 +40,35 @@ Logging can be controlled using LogObserver provided along or you can use your o
 
 In case you need no authentication leave `-u`/`--user` command line argument empty (default value).
 
+
+# Sending metrics
+
+To send a test metric to the twistd server you started above, you can run the following:
+```
+    python tests/scripts/sendPickle.py
+```
+Modify the script accordingly for your local testing
+
+# Configuration
+
+Configuration is done with command line arguments passed to twistd daemon when running:
+```
+    twistd -n -l - blueflood-forward --help
+
+```
+
+#Logging 
+
+Logging can be controlled using LogObserver provided along or you can use your own LogObserver
+
+```
+    twistd --logger carbonforwarderlogging.forwarder_log_observer.get_log_observer blueflood-forward
+```
+ 
 [blueflood-git]: https://github.com/rackerlabs/blueflood "blueflood"
+
+# Running unit tests
+```
+py.test
+```
+

--- a/bluefloodserver/collect.py
+++ b/bluefloodserver/collect.py
@@ -36,7 +36,7 @@ class BluefloodFlush(IFlush):
     @inlineCallbacks
     def flush(self, metrics):
         for name, time, value in metrics:
-            if self.metric_prefix != "":
+            if self.metric_prefix:
                 metric_name = self.metric_prefix + '.' + name
             else:
                 metric_name = name

--- a/bluefloodserver/collect.py
+++ b/bluefloodserver/collect.py
@@ -41,7 +41,6 @@ class BluefloodFlush(IFlush):
             else:
                 metric_name = name
             try:
-                log.msg('Ingesting metric name {}, timestamp {}, ttl {}'.format(metric_name, time, self.ttl), level=logging.DEBUG)
                 self.client.ingest(metric_name, time, value, self.ttl)
             except LimitExceededException:
                 yield self.client.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pytest==2.6.4
 Twisted==15.2.1
 zope.interface==4.1.2
 txKeystone==0.1.3
+nose==1.3.7
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 description-file = README.md
 
 [pytest]
-norecursedirs = .eggs .pyenv/ carbonforward
+norecursedirs = .eggs .pyenv/ carbonforward .tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 description-file = README.md
 
 [pytest]
-norecursedirs = .eggs /Users/shin4590/.pyenv/ carbonforward
+norecursedirs = .eggs .pyenv/ carbonforward

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.md
+
+[pytest]
+norecursedirs = .eggs /Users/shin4590/.pyenv/ carbonforward

--- a/tests/scripts/sendPickle.py
+++ b/tests/scripts/sendPickle.py
@@ -1,0 +1,21 @@
+import pickle
+import socket
+import struct
+import time
+import random
+
+LISTEN_URL = ('localhost', 2004)
+def send_to_socket(listOfMetricTuples):
+    payload = pickle.dumps(listOfMetricTuples, protocol=2)
+    header = struct.pack("!L", len(payload))
+    message = header + payload
+    print message
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect(LISTEN_URL)
+    sock.sendall(message)
+    sock.close()
+
+timestamp = int(time.time())
+value = random.randint(100, 200)
+name = 'my.metric.name.2'
+send_to_socket([(name, (timestamp, value))])

--- a/tests/scripts/sendPickle.py
+++ b/tests/scripts/sendPickle.py
@@ -1,3 +1,8 @@
+'''
+This is a simple test script that can be used to send pickle format 
+metric to a twistd server running blueflood-forward. 
+Modify the script as necessary for your testing need.
+'''
 import pickle
 import socket
 import struct

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ deps=
      pytest==2.6.4
      decorator==4.0.6
      testscenarios==0.5.0
-     testsresources==1.0.0
+     testresources==1.0.0
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,7 @@ deps=
      mock==1.0.1
      py==1.4.26
      pytest==2.6.4
-     decorator
+     decorator==4.0.6
+     testscenarios==0.5.0
+     testsresources==1.0.0
 commands=python setup.py test


### PR DESCRIPTION
**Why:**
Blueflood consumers who have regional Graphite installations and are using blueflood-forward need a way to distinguish metrics coming from each region, before they are sent to a centralized Blueflood server. They will need a way to prepend a custom string to metric names before they are sent to blueflood. For example: metrics coming from IAD Graphite installations can have a prefix "iad", and metrics coming from DFW Graphite can have a prefix "dfw"

**How:** 
Add an optional -p <prefix> parameter to blueflood-forward. The prefix will be prepended to all the metrics before they are sent to blueflood.