### PR TITLE
Treat 201,202,204 response code as success

### DIFF
--- a/bluefloodserver/blueflood.py
+++ b/bluefloodserver/blueflood.py
@@ -81,7 +81,7 @@ class BluefloodEndpoint():
 
         resp = yield d
         log.msg('POST {}, resp_code={}'.format(url, resp.code), level=logging.DEBUG)
-        if resp.code == 200:
+        if resp.code in [200,201,202,204]:
             self._json_buffer = []
             self._buffer_size = 0
         returnValue(None)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class PyTest(TestCommand):
 
 setup(
     name='blueflood-carbon-forwarder',
-    version="0.3.0",
+    version="0.3.1",
     url='https://github.com/rackerlabs/blueflood-carbon-forwarder',
     license='Apache Software License',
     author='Rackspace Metrics',


### PR DESCRIPTION
**What**
While debugging in Staging, our Blueflood server returns 202 and carbon-forwarder did not flush some of the buffers because it only checks for 200 being success.

I will also need to increase the version so I can upload this to PyPI

**How**
Add 201, 202, 204 as successful return code