### PR TITLE
Adds protocol class option to act as a full graphite replacement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ It does very primitive _'caching'_: aggregates all metrics and flushes them in r
 | --auth-url | Keystone token URL | |
 | --config | Set options from a config file | |
 | --overwrite_collection_timestamp | Replace metric collection timestamp with ingest timestamp | False |
+| --protocol | Listening protocol class. MetricPickleReceiver for receiving metrics from graphite, or MetricLineReceiver to act as a graphite replacement. | MetricPickleReceiver |
 
 In case you need no authentication leave `-u`/`--user` command line argument empty (default value).
 It is recommended not to set the `key` option from the command line, as that can compromise api keys. Instead, set the key in a config file and set the `--config` option to the name of the file.'

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class PyTest(TestCommand):
 
 setup(
     name='blueflood-carbon-forwarder',
-    version="0.4.1",
+    version="0.4.2",
     url='https://github.com/rackerlabs/blueflood-carbon-forwarder',
     license='Apache Software License',
     author='Rackspace Metrics',

--- a/twisted/plugins/graphite_blueflood_plugin.py
+++ b/twisted/plugins/graphite_blueflood_plugin.py
@@ -32,6 +32,7 @@ class Options(usage.Options):
         ['key',           'k', '', 'Rackspace authentication password. It is recommended not to set this option from the command line, as that can compromise api keys. Instead, set the key in a config file and use the \'--config\' option below.'],
         ['auth_url',      '',  AUTH_URL, 'Auth URL'],
         ['limit',         '',  0, 'Blueflood json payload limit, bytes. 0 means no limit'],
+        ['protocol',      '',  'MetricPickleReceiver', 'Listening protocol class. MetricPickleReceiver for receiving metrics from graphite, or MetricLineReceiver to act as a graphite replacement.'],
         ['overwrite_collection_timestamp',  '',  False, 'Replace metric time with current blueflood carbon forwarder node time'],
         ['config',        'c', None,
          'Path to a configuration file. The file must be in INI format, with '
@@ -137,8 +138,15 @@ class MetricServiceMaker(object):
                     value = int(value)
                 options[key] = value
 
+        if options['protocol'] == "MetricPickleReceiver":
+            protocol_cls = MetricPickleReceiver
+        elif options['protocol'] == "MetricLineReceiver":
+            protocol_cls = MetricLineReceiver
+        else:
+            protocol_cls = MetricPickleReceiver
+
         return MetricService(
-            protocol_cls=MetricPickleReceiver,
+            protocol_cls=protocol_cls,
             endpoint=options['endpoint'],
             interval=float(options['interval']),
             blueflood_url=options['blueflood'],


### PR DESCRIPTION
Currently, blueflood-carbon-forwarder can only receive pickle metrics, which means you have to have carbon-relay (or something similar) relaying metrics to blueflood-carbon-forwarder via pickled data.

With this PR, we will have the option to choose between received pickled metrics and receiving raw text metrics. The raw text metrics are what graphite itself is receiving.

This means I won't need to run the intermediate graphite node in order to get metrics from hosts via diamond, scripts, etc. -- I can now send directly from diamond to blueflood via blueflood-carbon-forwarder when running with the MetricLineReceiver protocol (rather than pickled protocol).